### PR TITLE
FIX: Ordering of navbar urls

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,8 +43,8 @@
                 <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
                     <div class="navbar-nav ms-auto">
                         <a class="nav-link active" aria-current="page" href="#">Home</a>
-                        <a class="nav-link" href="#services">Service</a>
                         <a class="nav-link" href="#about">About</a>
+                        <a class="nav-link" href="#services">Service</a>
                         <a class="nav-link " href="#contact">Contact</a>
                         <i class="fas fa-moon" id="toggleDark"></i>
                     </div>


### PR DESCRIPTION
Properly ordered the navbar urls.
"About" is before "Service".

Fixes #11

![Screenshot Capture - 2024-06-11 - 18-19-36](https://github.com/rajdeep010v2/Practice-Repo/assets/86741016/fb41e7ae-aabe-401c-9232-62ea4532d64c)
